### PR TITLE
functionality of the favourite toggle (heart) implemented to the detailed view

### DIFF
--- a/src/components/FavouriteToggle/FavouriteToggle.css
+++ b/src/components/FavouriteToggle/FavouriteToggle.css
@@ -1,3 +1,31 @@
 .dashboardFavourite__icon {
   cursor: pointer;
 }
+
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.tooltip .tooltiptext {
+  visibility: hidden;
+  width: 140px;
+  background-color: var(--color-light-blue);
+  color: var(--color-blue);
+  text-align: center;
+  border-radius: 4px;
+  padding: 3px;
+  font-size: 11px;
+  font-weight: lighter;
+  
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+  bottom: 100%;
+  left: 50%;
+  margin-left: -60px;
+}
+
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}

--- a/src/components/FavouriteToggle/FavouriteToggle.css
+++ b/src/components/FavouriteToggle/FavouriteToggle.css
@@ -1,0 +1,3 @@
+.dashboardFavourite__icon {
+  cursor: pointer;
+}

--- a/src/components/FavouriteToggle/FavouriteToggle.js
+++ b/src/components/FavouriteToggle/FavouriteToggle.js
@@ -12,6 +12,10 @@ class FavouriteToggle extends Component {
   heartFull = <i className="fas fa-heart dashboardFavourite__icon"></i>;
   heartEmpty = <i className="far fa-heart dashboardFavourite__icon"></i>;
 
+  componentDidMount() {
+    this.setState({ favStatus: this.state.object.favorite });
+  };
+
   toggleOnClick = () => {
     this.setState({ favStatus: !this.state.favStatus });
     const listModified = [...this.state.list];
@@ -23,18 +27,10 @@ class FavouriteToggle extends Component {
     localStorage.setItem("atractionData", JSON.stringify(listModified));
   }
 
-  componentDidMount() {
-    this.setState({ favStatus: this.state.object.favorite });
-  };
-
   render() {
     const heartIcon = this.state.favStatus ? this.heartFull : this.heartEmpty;
-
     return (
-      <div>
-        <p>{this.state.object.name}</p>
-        <span onClick={this.toggleOnClick}>{heartIcon}</span>
-      </div>
+      <span onClick={this.toggleOnClick}>{heartIcon}</span>
     )
   }
 }

--- a/src/components/FavouriteToggle/FavouriteToggle.js
+++ b/src/components/FavouriteToggle/FavouriteToggle.js
@@ -1,36 +1,39 @@
 import React, {Component} from 'react';
 import './FavouriteToggle.css';
-import atractionData from '../../atractionData';
+import attractionData from '../../attractionData';
 
 class FavouriteToggle extends Component {
   state = {
-    list: atractionData,
-    object: atractionData.find(el => el.id === this.props.id),
-    favStatus: false
+    attractionList: attractionData,
+    attractionFavouriteStatus: attractionData.find(el => el.id === this.props.id).favorite
   };
 
-  heartFull = <i className="fas fa-heart dashboardFavourite__icon"></i>;
-  heartEmpty = <i className="far fa-heart dashboardFavourite__icon"></i>;
+  heartFull = <i className="fas fa-heart dashboardFavourite__icon" />;
+  heartEmpty = <i className="far fa-heart dashboardFavourite__icon" />;
 
-  componentDidMount() {
-    this.setState({ favStatus: this.state.object.favorite });
-  };
-
-  toggleOnClick = () => {
-    this.setState({ favStatus: !this.state.favStatus });
-    const listModified = [...this.state.list];
-    listModified.forEach(el => {
-      if (el.id === this.props.id) {
-        el.favorite = !el.favorite;
-      };
-    });
-    localStorage.setItem("atractionData", JSON.stringify(listModified));
+  toggleClick = () => {
+    const listModified = this.state.attractionList.map(
+      el => 
+        el.id !== this.props.id ?
+          el 
+          :
+          { 
+            ...el, 
+            favorite: !el.favorite 
+          }
+    );
+    this.setState({ attractionList: listModified });
+    this.setState({ attractionFavouriteStatus: listModified.find(el => el.id === this.props.id).favorite });
+    localStorage.setItem("attractionData", JSON.stringify(listModified));
   }
 
   render() {
-    const heartIcon = this.state.favStatus ? this.heartFull : this.heartEmpty;
+    const heartIcon = this.state.attractionFavouriteStatus ? this.heartFull : this.heartEmpty;
+    const tooltipText = this.state.attractionFavouriteStatus ? "usuń z ulubionych" : "dodaj do ulubionych";
     return (
-      <span onClick={this.toggleOnClick}>{heartIcon}</span>
+      <span className="tooltip" onClick={this.toggleClick}>{heartIcon}
+        <span className="tooltiptext">{tooltipText}</span>
+      </span>
     )
   }
 }

--- a/src/components/FavouriteToggle/FavouriteToggle.js
+++ b/src/components/FavouriteToggle/FavouriteToggle.js
@@ -1,0 +1,42 @@
+import React, {Component} from 'react';
+import './FavouriteToggle.css';
+import atractionData from '../../atractionData';
+
+class FavouriteToggle extends Component {
+  state = {
+    list: atractionData,
+    object: atractionData.find(el => el.id === this.props.id),
+    favStatus: false
+  };
+
+  heartFull = <i className="fas fa-heart dashboardFavourite__icon"></i>;
+  heartEmpty = <i className="far fa-heart dashboardFavourite__icon"></i>;
+
+  toggleOnClick = () => {
+    this.setState({ favStatus: !this.state.favStatus });
+    const listModified = [...this.state.list];
+    listModified.forEach(el => {
+      if (el.id === this.props.id) {
+        el.favorite = !el.favorite;
+      };
+    });
+    localStorage.setItem("atractionData", JSON.stringify(listModified));
+  }
+
+  componentDidMount() {
+    this.setState({ favStatus: this.state.object.favorite });
+  };
+
+  render() {
+    const heartIcon = this.state.favStatus ? this.heartFull : this.heartEmpty;
+
+    return (
+      <div>
+        <p>{this.state.object.name}</p>
+        <span onClick={this.toggleOnClick}>{heartIcon}</span>
+      </div>
+    )
+  }
+}
+
+export default FavouriteToggle;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -8,7 +8,7 @@ class Sidebar extends Component {
         <nav className={this.props.visibility}>
             <Link to="/" className="sidebar__link" onClick={this.props.changeVisibility}>Strona główna</Link>
             <Link to="/placelist" className="sidebar__link" onClick={this.props.changeVisibility}>Wszystkie atrakcje</Link>
-            <Link to="/placelist" className="sidebar__link" onClick={this.props.changeVisibility}>Moje ulubione</Link>
+            <Link to="/myfavourites" className="sidebar__link" onClick={this.props.changeVisibility}>Moje ulubione</Link>
             <Link to="/addnewplace" className="sidebar__link" onClick={this.props.changeVisibility}>Dodaj własną atrakcję</Link>
         </nav>
         )

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import AddNewPlace from './pages/AddNewPlace/AddNewPlace';
 import NewPlaceAdded from './pages/NewPlaceAdded/NewPlaceAdded';
 import PlaceDetails from './pages/PlaceDetails/PlaceDetails';
 import PlaceList from './pages/PlaceList/PlacesList';
+import FavouriteList from './pages/FavouriteList/FavouriteList';
 import Default from './pages/Default/Default';
 import './index.css';
 import * as serviceWorker from './serviceWorker';
@@ -21,6 +22,7 @@ ReactDOM.render(
             <Route path="/placeadded" component={NewPlaceAdded} />
             <Route path="/placedetails" component={PlaceDetails} />
             <Route path="/placelist" component={PlaceList} />
+            <Route path="/myfavourites" component={FavouriteList} />
             <Route component={Default} />
         </Switch>
     </BrowserRouter>, document.getElementById('root')

--- a/src/pages/FavouriteList/FavouriteList.css
+++ b/src/pages/FavouriteList/FavouriteList.css
@@ -1,0 +1,11 @@
+.dashboardFavourite {
+  padding: 70px 10px 10px 10px;
+  text-align: center;
+  font-size: 30px;
+}
+
+@media (min-width: 900px) {
+  .dashboardFavourite {
+      padding: 70px 10px 10px 230px;
+  }
+}

--- a/src/pages/FavouriteList/FavouriteList.css
+++ b/src/pages/FavouriteList/FavouriteList.css
@@ -1,6 +1,5 @@
 .dashboardFavourite {
   padding: 70px 10px 10px 10px;
-  text-align: center;
   font-size: 30px;
 }
 

--- a/src/pages/FavouriteList/FavouriteList.js
+++ b/src/pages/FavouriteList/FavouriteList.js
@@ -4,9 +4,9 @@ import './FavouriteList.css';
 class FavouriteList extends Component {
     render() {
         return( 
-        <main className="dashboardFavourite">
-            
-        </main>
+            <main className="dashboardFavourite">
+                
+            </main>
         )
     }
 }

--- a/src/pages/FavouriteList/FavouriteList.js
+++ b/src/pages/FavouriteList/FavouriteList.js
@@ -1,0 +1,14 @@
+import React, {Component} from 'react';
+import './FavouriteList.css';
+
+class FavouriteList extends Component {
+    render() {
+        return( 
+        <main className="dashboardFavourite">
+            
+        </main>
+        )
+    }
+}
+
+export default FavouriteList;

--- a/src/pages/PlaceDetails/PlaceDetails.css
+++ b/src/pages/PlaceDetails/PlaceDetails.css
@@ -37,6 +37,10 @@
     font-size: 18px;
 }
 
+.dashboardFavourite__icon {
+    color: var(--color-blue);
+}
+
 @media (min-width: 900px) {
     .placeDetails {
         padding: 70px 10px 10px 230px;

--- a/src/pages/PlaceDetails/PlaceDetails.js
+++ b/src/pages/PlaceDetails/PlaceDetails.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import "./PlaceDetails.css";
 import attractionData from "../../attractionData";
+import FavouriteToggle from "../../components/FavouriteToggle/FavouriteToggle";
 
 class PlaceDetails extends Component {
     render() {
@@ -20,10 +21,9 @@ class PlaceDetails extends Component {
                             />
                         </div>
                         <div className="dashboard__placeDetails--right">
-                            {/* <div className="dashboard__placeDetails--favourite">
-                            </div> miejsce na dodanie komponentu favourite */}
                             <h2 className="dashboard__placeDetails--name">
-                                {attraction.name}
+                                {attraction.name + " "}
+                                <FavouriteToggle id={Number(this.props.match.params.id)} />
                             </h2>
                             <h3 className="dashboard__placeDetails--location">
                                 {attraction.location}


### PR DESCRIPTION
Heart icon added to the detailed view of the attraction -> placedetails/:id
It:
-checks the list of all attractions in the local storage
-initially sets a full or an empty heart icon depending on the attraction favorite property
-when clicked changes the attraction favorite property to the opposite
The /placedetails page component is still under construction ;)